### PR TITLE
up

### DIFF
--- a/util.js
+++ b/util.js
@@ -50,7 +50,8 @@ export const transformer = (message) => {
 
 export const getSlackMessages = async(client, channelId, targetDate) => {
   const result = await client.conversations.history({
-    channel: channelId
+    channel: channelId,
+    limit: 999
   });
 
   console.warn(`${result.messages.length}: Slack投稿`);


### PR DESCRIPTION
52a2b7b chore: change slack conversation history records. default to 999(MAX)

doc: https://api.slack.com/methods/conversations.history#arg_limit