### PR TITLE
fix: ネストしたリストを4スペースインデントで出力する

### DIFF
--- a/test_daily_note_nested_list.md
+++ b/test_daily_note_nested_list.md
@@ -1,0 +1,21 @@
+---
+date: 2023-08-01
+score: 50
+title:
+---
+
+## Sample
+
+サンプルの文章を色々
+
+## Journal
+
+- 00:20 test
+    - ネスト1
+        - ネスト2
+- 00:30 test
+
+## Habits
+
+- [ ] hoge
+- [ ] fuga

--- a/util.js
+++ b/util.js
@@ -33,12 +33,17 @@ export const astToMarkdown = (ast) => {
       .replace(/\\\*/g, "*");
   };
 
+  // toMarkdownはネストしたリストを2スペースでインデントするため、Obsidianに合わせて4スペースに広げる
+  const expandListIndent = (str) => {
+    return str.replace(/^( +)(?=[-*+] |\d+[.)] )/gm, (indent) => indent.repeat(2));
+  };
+
   const options = {
     bullet: '-',
     extensions: [frontmatterToMarkdown(['yaml'])]
   }
 
-  return replacer(toMarkdown(ast, options));
+  return expandListIndent(replacer(toMarkdown(ast, options)));
 }
 
 export const targetDates = (baseDate, term = 1) => {

--- a/util.test.js
+++ b/util.test.js
@@ -180,5 +180,12 @@ describe('Convert AST and Markdown', () => {
 
     expect(markdown).toBe(fs.readFileSync('./test_daily_note_memos1.md', 'utf8'));
   });
+
+  test('ネストしたリストは4スペースインデントで出力される', () => {
+    const ast = markdownToAst('./test_daily_note_nested_list.md');
+    const markdown = astToMarkdown(ast);
+
+    expect(markdown).toBe(fs.readFileSync('./test_daily_note_nested_list.md', 'utf8'));
+  });
 });
 


### PR DESCRIPTION
## 概要

Markdown出力時にネストしたリストのインデントが2スペースに潰される問題を修正し、4スペースで出力されるようにする。

## Why

- Markdownの再生成に使っている `mdast-util-to-markdown` は、ネストリストを親バレット幅（`- ` = 2スペース）でインデントする仕様
- そのため、Obsidianのデフォルト（タブ幅4）で書いたデイリーノートのネストリストが、Slack投稿マージのたびに2スペースへ書き換えられてしまっていた

## How

- ライブラリには「バレット後は1スペースのまま、ネストだけ4スペース」にするオプションがない（`listItemIndent: 'tab'` だと `-   item` のように全行の見た目が変わってしまう）ため、既存の `replacer` と同様の後処理方式で対応
- `astToMarkdown` に `expandListIndent` を追加し、リスト行（`-`/`*`/`+`/番号付き）の行頭インデントを2倍にして2スペース単位→4スペース単位へ変換
  - 深いネストも正しく変換される（4スペース→8スペース）
- 4スペースネストを含むテストフィクスチャ `test_daily_note_nested_list.md` を追加し、ラウンドトリップテストを追加

## 確認観点

- [x] 既存テストがすべてパスすること（既存の出力への影響がないこと）
- [x] 4スペースネストのリストを含むファイルがラウンドトリップで変化しないこと（新規テストで担保）
- [x] `npm test` 18件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)